### PR TITLE
 Cache HTTP/HTTPS separate

### DIFF
--- a/conf/default.vcl.tmpl
+++ b/conf/default.vcl.tmpl
@@ -172,3 +172,10 @@ sub vcl_synth {
 "} );
   return (deliver);
 }
+
+# Cache HTTP and HTTPS separate.
+sub vcl_hash {
+  if (req.http.X-Forwarded-Proto) {
+    hash_data(req.http.X-Forwarded-Proto);
+  }
+}


### PR DESCRIPTION
Right now varnish caches either HTTP or HTTPS pages. This  can lead to unexpected behavior, especially with Apache .htaccess HTTP to HTTPS redirect rules.  (Redirect loops). Think it makes to hash them based on X-Forwarded-Proto. 